### PR TITLE
added auto deployment

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,6 +1,7 @@
 # Purpose: Build and push Docker image to DockerHub
+# SSH on remote server and run docker commands to update running bot
 
-name: Docker CI
+name: Docker CICD
 
 on:
   push:
@@ -12,7 +13,7 @@ env:
   TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       -
@@ -35,3 +36,32 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ env.USERNAME }}/progphil-bot:latest
+  
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        
+      -
+        name: Configure SSH Key permissions
+        
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/pph.key
+          chmod 600 ~/.ssh/pph.key
+          cat >>~/.ssh/config <<END
+          
+      - 
+        name: Deploy on Server
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            docker stop progphil-bot || true && docker rm progphil-bot || true
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/progphil-bot:latest
+            docker run --env token=${{secrets.PPH_TEST_SERVER_BOT_TOKEN }} -it -d ${{ secrets.DOCKERHUB_USERNAME }}/progphil-bot:latest


### PR DESCRIPTION
Added deployment job dependent on build job

# Description
Once a certain PR was merged into main branch , this action will:
1.) Create a docker image and push it on dockerhub
2.) Will ssh on server automatically, pull the updated image on docker hub stop the server and run new image.

TLDR: After merge to main branch action will automatically restart and deploy the bot using updated code.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
It was tested on a fork of this repository

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
