### PR TITLE
Fix: Added Auto release actions using release-please-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    branches:
+      # Matches all release branches like: release/2023-01 or release/2023-01-01
+      - 'release/[0-9][0-9][0-9][0-9]-*' 
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - # Please follow conventional-commits convention on commits.
+        # https://www.conventionalcommits.org/en/v1.0.0/
+        name: Create Release
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: simple
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: "progphil-bot"
+  deploy:
+    name: Deploy Release
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure SSH Key permissions
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/pph.key
+          chmod 600 ~/.ssh/pph.key
+          cat >>~/.ssh/config <<END
+          Host staging
+            HostName $SSH_HOST
+            User $SSH_USER
+            IdentityFile ~/.ssh/pph.key
+            StrictHostKeyChecking no
+          END
+        env:
+          SSH_USER: ${{ secrets.SERVER_USERNAME }}
+          SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+          SSH_HOST: ${{ secrets.SERVER_HOST }}
+      - # Re-deploying to the server as a prod container. 
+        name:  Deploy to Server
+        uses: garygrossgarten/github-action-ssh@release
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          privateKey: ${{ env.SERVER_SSH_KEY }}
+          command: |
+            cd pph
+            git pull
+            docker stop progphil-bot-prod || true && docker rm progphil-bot-prod || true
+            docker rm progphil-bot-prod
+            docker build -t progphil-bot-prod .
+            docker run --env token=${{secrets.PPH_TEST_SERVER_BOT_TOKEN }} -it -d  --name progphil-bot-prod progphil-bot-prod
+            docker image prune -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,5 @@ jobs:
             docker stop progphil-bot-prod || true && docker rm progphil-bot-prod || true
             docker rm progphil-bot-prod
             docker build -t progphil-bot-prod .
-            docker run --env token=${{secrets.PPH_TEST_SERVER_BOT_TOKEN }} -it -d  --name progphil-bot-prod progphil-bot-prod
+            docker run --env token=${{secrets.PPH_PROD_SERVER_BOT_TOKEN }} -it -d  --name progphil-bot-prod progphil-bot-prod
             docker image prune -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
             cd pph
             git pull
             docker stop progphil-bot-prod || true && docker rm progphil-bot-prod || true
-            docker rm progphil-bot-prod
             docker build -t progphil-bot-prod .
             docker run --env token=${{secrets.PPH_PROD_SERVER_BOT_TOKEN }} -it -d  --name progphil-bot-prod progphil-bot-prod
             docker image prune -f


### PR DESCRIPTION
# Description

This action will automate releases in release branches that has this pattern: `[0-9][0-9][0-9][0-9]-*` i.e. `release/2023-01` or `release/2023-1`, and automatically deploy it on the server as prod. Upon implementing this feature, **ALL COMMITS** should follow 
[conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/) commits convention in order to be tracked in `CHANGELOG.md`. By default, the versioning strategy of conventional-commits follows [semver](https://semver.org), I think that's the standard. This is related to prod, please review with caution. Thank you! :wave: 

Fixes # (issue)

Initial Infrastructure

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
