### PR TITLE
Chore/define word ephemeral

### DIFF
--- a/bot/cogs/announcements.py
+++ b/bot/cogs/announcements.py
@@ -48,6 +48,7 @@ class Announcements(Cog):
             ephemeral=True
         )
         await channel.send(message)
+        
 
     @is_staff()
     @command(name="announce",

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -37,9 +37,15 @@ class define(GroupCog):
         if "title" in response.json() and response.json()["title"] == "No Definitions Found":
             respond_message=response.json()['message']
         else:
-            output=response.json()[0]
-            definition=output['meanings'][0]['definitions'][0]['definition']
-            respond_message="Word: "+word+"\nDefinition: "+str(definition)
+            definitions=''
+            for words in response.json():
+                for meaning in words['meanings']:
+                    for definition in meaning['definitions']:
+                        definitions+=definition['definition']+'\n'
+            
+            # output=response.json()[0]
+            # definition=output['meanings'][0]['definitions'][0]['definition']
+            respond_message="Here's what i got on the Word "+word+"\n\n"+definitions
         await interaction.response.send_message(respond_message)
 
     @is_staff()

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -1,5 +1,6 @@
 import requests
 import discord
+from discord.ui import Button, View
 from discord import Embed
 from discord.ext.commands import Bot
 from discord.app_commands import command, describe
@@ -33,7 +34,6 @@ class Define(GroupCog):
 
         url = "https://api.dictionaryapi.dev/api/v2/entries/en/" + word
         response = requests.get(url)
-
         if "title" in response.json() and response.json()["title"] == "No Definitions Found":
             message = response.json()['message']
             respond_message = Embed(
@@ -41,8 +41,11 @@ class Define(GroupCog):
                 description=message,
                 color=discord.Color.blurple()
             )
+            await interaction.response.send_message(embed=respond_message) 
+            return
         else:
             definitions = ''
+            defs = []
             num = 1
             for words in response.json():
                 for meaning in words['meanings']:
@@ -50,16 +53,53 @@ class Define(GroupCog):
                         part_of_speech = meaning['partOfSpeech']
                         definitions += f'({str(part_of_speech)}) ' + \
                             str(num)+'. '+definition['definition'] + '\n'
+                        defs.append(f'({str(part_of_speech)}) ' +
+                                    str(num)+'. '+definition['definition'] + '\n')
                         num += 1
+        global index_count
+        index_count = 0
 
-            message = f"Here's what i got on the Word {word} \n\n {definitions}"
+        def create_embed(mode):
+            global index_count
+
+            if mode == 'next':
+                index_count += 1
+            elif mode == 'previous':
+                index_count -= 1
+
+            if index_count >= len(defs):
+                index_count = -1
+            elif index_count < 0:
+                index_count = 0
+
+            message = f"Here's what i got on the Word {word} \n\n {defs[index_count]}"
             respond_message = Embed(
                 title=word,
                 description=message,
                 color=discord.Color.blurple()
             )
 
-        await interaction.response.send_message(embed=respond_message)
+            return respond_message
+
+        async def callback_next(interaction):
+            respond_message = create_embed('next')
+            await interaction.response.edit_message(embed=respond_message, view=view)
+
+        async def callback_previous(interaction):
+            respond_message = create_embed('previous')
+            await interaction.response.edit_message(embed=respond_message, view=view)
+
+        button_next = Button(
+            label='Next', style=discord.ButtonStyle.green, emoji='➡')
+        button_previous = Button(
+            label='Previous', style=discord.ButtonStyle.green, emoji='⬅')
+        button_next.callback = callback_next
+        button_previous.callback = callback_previous
+        view = View()
+        view.add_item(button_previous)
+        view.add_item(button_next)
+
+        await interaction.response.send_message(embed=create_embed('first'), view=view)
 
     # Command to Turn this Command On or Off
     @is_staff()

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -6,14 +6,16 @@ from utils.decorators import is_staff
 from discord.ext.commands import GroupCog
 
 
-command_enabled = True
+# Global Variable that will define if Command is Turned On or Off.
+# In Every Restart, this command is by default Turned On.
+command_enabled = True 
 
-class define(GroupCog):
-    def __init__ (self, bot: Bot):
+class Define(GroupCog):
+    def __init__(self, bot: Bot):
         self.bot = bot
 
-    @command(name="word",
-             description="Give Dictionary Definition to the Given Word")
+    # The Actual Define Command
+    @command(name="word", description="Give Dictionary Definition to the Given Word")
     @describe(word="The Word that will be Defined")
     async def define(
         self,
@@ -27,30 +29,31 @@ class define(GroupCog):
         :param word: The Word to Define
         """
         global command_enabled
-        if command_enabled==False:
+        if not command_enabled:
             await interaction.response.send_message("Sorry, this command is currently disabled.")
             return
         
-        url = "https://api.dictionaryapi.dev/api/v2/entries/en/"+word
-        response=requests.get(url)
+        url = "https://api.dictionaryapi.dev/api/v2/entries/en/" + word
+        response = requests.get(url)
         
         if "title" in response.json() and response.json()["title"] == "No Definitions Found":
-            respond_message=response.json()['message']
+            respond_message = response.json()['message']
         else:
             definitions=''
             for words in response.json():
                 for meaning in words['meanings']:
                     for definition in meaning['definitions']:
-                        definitions+=definition['definition']+'\n'
+                        definitions += definition['definition'] + '\n'
             
             # output=response.json()[0]
             # definition=output['meanings'][0]['definitions'][0]['definition']
-            respond_message="Here's what i got on the Word "+word+"\n\n"+definitions
+            
+            respond_message = f"Here's what i got on the Word {word} \n\n {definitions}"
         await interaction.response.send_message(respond_message)
 
+    # Command to Turn this Command On or Off
     @is_staff()
-    @command(name="toggle",
-             description="Turn Define Command On/Off")
+    @command(name="toggle", description="Turn Define Command On/Off")
     async def defineOnOff(
         self,
         interaction: discord.Interaction,
@@ -62,15 +65,15 @@ class define(GroupCog):
         """
         global command_enabled
 
-        if command_enabled==True:
-            command_enabled= False
-            response="Command is now Disabled"
+        if command_enabled == True:
+            command_enabled = False
+            response = "Command is now Disabled"
         else:
-            command_enabled=True
-            response="Command is now Enabled"
+            command_enabled = True
+            response = "Command is now Enabled"
 
         await interaction.response.send_message(response)
         
 
 async def setup(bot: Bot):
-    await bot.add_cog(define(bot))
+    await bot.add_cog(Define(bot))

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -2,19 +2,16 @@ import requests
 import discord
 from discord.ext.commands import Bot
 from discord.app_commands import command, describe
-from utils.decorators import is_staff 
 from discord.ext.commands import GroupCog
 
+from utils.decorators import is_staff
 
-# Global Variable that will define if Command is Turned On or Off.
-# In Every Restart, this command is by default Turned On.
-command_enabled = True 
 
 class Define(GroupCog):
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.command_enabled = True
 
-    # The Actual Define Command
     @command(name="word", description="Give Dictionary Definition to the Given Word")
     @describe(word="The Word that will be Defined")
     async def define(
@@ -28,33 +25,31 @@ class Define(GroupCog):
         :param interaction: Interaction
         :param word: The Word to Define
         """
-        global command_enabled
-        if not command_enabled:
+
+        if not self.command_enabled:
             await interaction.response.send_message("Sorry, this command is currently disabled.")
             return
-        
+
         url = "https://api.dictionaryapi.dev/api/v2/entries/en/" + word
         response = requests.get(url)
-        
+
         if "title" in response.json() and response.json()["title"] == "No Definitions Found":
             respond_message = response.json()['message']
         else:
-            definitions=''
+            definitions = ''
+
             for words in response.json():
                 for meaning in words['meanings']:
                     for definition in meaning['definitions']:
                         definitions += definition['definition'] + '\n'
-            
-            # output=response.json()[0]
-            # definition=output['meanings'][0]['definitions'][0]['definition']
-            
+
             respond_message = f"Here's what i got on the Word {word} \n\n {definitions}"
         await interaction.response.send_message(respond_message)
 
     # Command to Turn this Command On or Off
     @is_staff()
     @command(name="toggle", description="Turn Define Command On/Off")
-    async def defineOnOff(
+    async def toggle(
         self,
         interaction: discord.Interaction,
     ) -> None:
@@ -63,17 +58,16 @@ class Define(GroupCog):
 
         :param interaction: Interaction
         """
-        global command_enabled
 
-        if command_enabled == True:
-            command_enabled = False
+        if self.command_enabled:
+            self.command_enabled = False
             response = "Command is now Disabled"
         else:
-            command_enabled = True
+            self.command_enabled = True
             response = "Command is now Enabled"
 
         await interaction.response.send_message(response)
-        
+
 
 async def setup(bot: Bot):
     await bot.add_cog(Define(bot))

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -1,5 +1,6 @@
 import requests
 import discord
+from discord import Embed
 from discord.ext.commands import Bot
 from discord.app_commands import command, describe
 from discord.ext.commands import GroupCog
@@ -34,17 +35,31 @@ class Define(GroupCog):
         response = requests.get(url)
 
         if "title" in response.json() and response.json()["title"] == "No Definitions Found":
-            respond_message = response.json()['message']
+            message = response.json()['message']
+            respond_message = Embed(
+                title=word,
+                description=message,
+                color=discord.Color.blurple()
+            )
         else:
             definitions = ''
-
+            num = 1
             for words in response.json():
                 for meaning in words['meanings']:
                     for definition in meaning['definitions']:
-                        definitions += definition['definition'] + '\n'
+                        part_of_speech = meaning['partOfSpeech']
+                        definitions += f'({str(part_of_speech)}) ' + \
+                            str(num)+'. '+definition['definition'] + '\n'
+                        num += 1
 
-            respond_message = f"Here's what i got on the Word {word} \n\n {definitions}"
-        await interaction.response.send_message(respond_message)
+            message = f"Here's what i got on the Word {word} \n\n {definitions}"
+            respond_message = Embed(
+                title=word,
+                description=message,
+                color=discord.Color.blurple()
+            )
+
+        await interaction.response.send_message(embed=respond_message)
 
     # Command to Turn this Command On or Off
     @is_staff()

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -1,14 +1,18 @@
 import requests
 import discord
-from discord.ext.commands import Bot, Cog
-from discord.app_commands import Choice, choices, command, describe
+from discord.ext.commands import Bot
+from discord.app_commands import command, describe
 from utils.decorators import is_staff 
+from discord.ext.commands import GroupCog
 
-class defineWord(Cog):
+
+command_enabled = True
+
+class define(GroupCog):
     def __init__ (self, bot: Bot):
         self.bot = bot
 
-    @command(name="define",
+    @command(name="word",
              description="Give Dictionary Definition to the Given Word")
     @describe(word="The Word that will be Defined")
     async def define(
@@ -22,6 +26,10 @@ class defineWord(Cog):
         :param interaction: Interaction
         :param word: The Word to Define
         """
+        global command_enabled
+        if command_enabled==False:
+            await interaction.response.send_message("Sorry, this command is currently disabled.")
+            return
         
         url = "https://api.dictionaryapi.dev/api/v2/entries/en/"+word
         response=requests.get(url)
@@ -33,7 +41,30 @@ class defineWord(Cog):
             definition=output['meanings'][0]['definitions'][0]['definition']
             respond_message="Word: "+word+"\nDefinition: "+str(definition)
         await interaction.response.send_message(respond_message)
+
+    @is_staff()
+    @command(name="toggle",
+             description="Turn Define Command On/Off")
+    async def defineOnOff(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        """
+        Turn Define Command On/Off
+
+        :param interaction: Interaction
+        """
+        global command_enabled
+
+        if command_enabled==True:
+            command_enabled= False
+            response="Command is now Disabled"
+        else:
+            command_enabled=True
+            response="Command is now Enabled"
+
+        await interaction.response.send_message(response)
         
 
 async def setup(bot: Bot):
-    await bot.add_cog(defineWord(bot))
+    await bot.add_cog(define(bot))

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -1,0 +1,35 @@
+import requests
+import discord
+from discord.ext.commands import Bot, Cog
+from discord.app_commands import Choice, choices, command, describe
+from utils.decorators import is_staff 
+
+class defineWord(Cog):
+    def __init__ (self, bot: Bot):
+        self.bot = bot
+
+    @command(name="define",
+             description="Give Dictionary Definition to the Given Word")
+    @describe(word="The Word that will be Defined")
+    async def define(
+        self,
+        interaction: discord.Interaction,
+        word: str,
+    ) -> None:
+        """
+        Give Dictionary Definition to the Given Word
+
+        :param interaction: Interaction
+        :param word: The Word to Define
+        """
+        
+        url = "https://api.dictionaryapi.dev/api/v2/entries/en/"+word
+        response=requests.get(url)
+        output=response.json()[0]
+        definition=output['meanings'][0]['definitions'][0]['definition']
+        respond_message="Word: "+word+"\nDefinition: "+str(definition)
+        await interaction.response.send_message(respond_message)
+        
+
+async def setup(bot: Bot):
+    await bot.add_cog(defineWord(bot))

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -29,7 +29,7 @@ class Define(GroupCog):
         """
 
         if not self.command_enabled:
-            await interaction.response.send_message("Sorry, this command is currently disabled.")
+            await interaction.response.send_message("Sorry, this command is currently disabled.", ephemeral=True)
             return
 
         url = "https://api.dictionaryapi.dev/api/v2/entries/en/" + word
@@ -41,18 +41,15 @@ class Define(GroupCog):
                 description=message,
                 color=discord.Color.blurple()
             )
-            await interaction.response.send_message(embed=respond_message) 
+            await interaction.response.send_message(embed=respond_message)
             return
         else:
-            definitions = ''
             defs = []
             num = 1
             for words in response.json():
                 for meaning in words['meanings']:
                     for definition in meaning['definitions']:
                         part_of_speech = meaning['partOfSpeech']
-                        definitions += f'({str(part_of_speech)}) ' + \
-                            str(num)+'. '+definition['definition'] + '\n'
                         defs.append(f'({str(part_of_speech)}) ' +
                                     str(num)+'. '+definition['definition'] + '\n')
                         num += 1
@@ -121,7 +118,7 @@ class Define(GroupCog):
             self.command_enabled = True
             response = "Command is now Enabled"
 
-        await interaction.response.send_message(response)
+        await interaction.response.send_message(response, ephemeral=True)
 
 
 async def setup(bot: Bot):

--- a/bot/cogs/define_word.py
+++ b/bot/cogs/define_word.py
@@ -25,9 +25,13 @@ class defineWord(Cog):
         
         url = "https://api.dictionaryapi.dev/api/v2/entries/en/"+word
         response=requests.get(url)
-        output=response.json()[0]
-        definition=output['meanings'][0]['definitions'][0]['definition']
-        respond_message="Word: "+word+"\nDefinition: "+str(definition)
+        
+        if "title" in response.json() and response.json()["title"] == "No Definitions Found":
+            respond_message=response.json()['message']
+        else:
+            output=response.json()[0]
+            definition=output['meanings'][0]['definitions'][0]['definition']
+            respond_message="Word: "+word+"\nDefinition: "+str(definition)
         await interaction.response.send_message(respond_message)
         
 


### PR DESCRIPTION
# Description
made responses ephemeral when message sent was 'command disabled/enabled'

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

added ephemeral argument to existing interaction.response.send_message function that sends message when define word command was disabled or enabled.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
