### PR TITLE
bug fix: fixed discord's behaviour on old members triggering onboarding

### DIFF
--- a/bot/cogs/welcome.py
+++ b/bot/cogs/welcome.py
@@ -8,6 +8,8 @@ from database.welcome import WelcomeDB
 
 from utils.decorators import is_staff
 
+from datetime import datetime, timedelta, timezone
+
 class Welcomer(GroupCog):
     def __init__(self, bot: Bot):
         self.bot = bot
@@ -47,10 +49,13 @@ class Welcomer(GroupCog):
         member_flags_before: MemberFlags = before.flags
         member_flags_after: MemberFlags = after.flags
         
-        # Check before and after state of the user's MemberFlags if they finished onboarding
         if (
-            not member_flags_before.completed_onboarding
-            and member_flags_after.completed_onboarding
+            # Check before and after state of the user's MemberFlags if they finished onboarding
+           (not member_flags_before.completed_onboarding
+            and member_flags_after.completed_onboarding)
+            # Check if they onboarded within 1 day of joining
+            and after.joined_at != None
+            and  after.joined_at >= datetime.now(timezone.utc) - timedelta(day=1) 
         ):
             result = await self.db.get_message()
             if result is None:


### PR DESCRIPTION
# Description

Added condition where the welcomer feature only triggers when the member has on-boarded within 1 day of joining the server to prevent old users from triggering the feature.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

