### PR TITLE
chore: simplify calculate_next_run()

### DIFF
--- a/src/cogs/forum/forum_showcase.py
+++ b/src/cogs/forum/forum_showcase.py
@@ -157,17 +157,18 @@ class ForumShowcaseCog(GroupCog, name="forum-showcase"):
         )
 
         while next_run <= now:
-            if interval == "daily":
-                next_run += relativedelta(days=1)
-            elif interval == "weekly":
-                if weekday_int == now.weekday():
-                    next_run += relativedelta(weeks=1)
-                else:
-                    weekday = weekday_int
-                    next_run += relativedelta(weekday=weekday)
-            elif interval == "monthly":
-                next_month = next_run.replace(day=1) + relativedelta(months=1)
-                next_run = next_month.replace(day=next_month.day)
+            match interval:
+                case "daily":
+                    next_run += relativedelta(days=1)
+                case "weekly":
+                    if weekday_int == now.weekday():
+                        next_run += relativedelta(weeks=1)
+                    else:
+                        next_run += relativedelta(weekday=weekday_int)
+                case "monthly":
+                    next_month = next_run.replace(
+                        day=1) + relativedelta(months=1)
+                    next_run = next_month
 
         return next_run
 


### PR DESCRIPTION
# Description

#### Changes made:
- Replaced if/elif chain with match/case for clearer interval handling (Python 3.10+)
- Removed redundant `weekday` variable
- Simplified the monthly case by removing an unnecessary `.replace(day=next_month.day)` call, as the day will always be `1`

#### Why:
- Code clarity and maintainability
- Eliminate redundant operations
- Make future modifications easier

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] DevOps / CI changes

# How Has This Been Tested?

Eyeballed it

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
