### PR TITLE
[FIX] Extra whitespace between the title and content of an announcement

### DIFF
--- a/src/cogs/admin/test_announcements.py
+++ b/src/cogs/admin/test_announcements.py
@@ -6,7 +6,24 @@ from discord import Interaction
 from discord.app_commands import Choice
 
 from src.cogs.admin.announcements import Announcements
-from src.ui.modals.announcement import Announcement
+from src.ui.modals.announcement import Announcement, _format_announcement
+
+
+class TestAnnouncementFormatting(unittest.TestCase):
+    def test_format_announcement_with_title_uses_single_newline(self):
+        announcement = _format_announcement("my title", "test")
+
+        self.assertEqual(announcement, "**my title**\ntest")
+
+    def test_format_announcement_without_title_has_no_leading_newline(self):
+        announcement = _format_announcement("", "test")
+
+        self.assertEqual(announcement, "test")
+
+    def test_format_announcement_with_whitespace_title_treats_it_as_missing(self):
+        announcement = _format_announcement("   ", "test")
+
+        self.assertEqual(announcement, "test")
 
 
 class TestAnnouncements(IsolatedAsyncioTestCase):
@@ -48,6 +65,52 @@ class TestAnnouncements(IsolatedAsyncioTestCase):
 
         self.assertIsInstance(sent_modal, Announcement)
         mock_wait.assert_awaited_once()
+
+    async def test_on_submit_regular_submission_uses_single_newline(self):
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+
+        mock_interaction = MagicMock(spec=Interaction)
+        mock_interaction.response = MagicMock()
+        mock_interaction.response.is_done = MagicMock(return_value=False)
+        mock_interaction.response.send_message = AsyncMock()
+        mock_interaction.followup = MagicMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        modal = Announcement(None, mock_channel, "regular")
+        modal.announcement_title = MagicMock(value="my title")
+        modal.announcement = MagicMock(value="test")
+
+        await modal.on_submit(mock_interaction)
+
+        mock_channel.send.assert_awaited_once_with(
+            content="**my title**\ntest",
+            file=None
+        )
+
+    async def test_on_submit_embed_submission_skips_leading_newline_without_title(self):
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+
+        mock_interaction = MagicMock(spec=Interaction)
+        mock_interaction.response = MagicMock()
+        mock_interaction.response.is_done = MagicMock(return_value=False)
+        mock_interaction.response.send_message = AsyncMock()
+        mock_interaction.followup = MagicMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        modal = Announcement(None, mock_channel, "embed")
+        modal.announcement_title = MagicMock(value="   ")
+        modal.announcement = MagicMock(value="test")
+
+        await modal.on_submit(mock_interaction)
+
+        mock_channel.send.assert_awaited_once()
+        self.assertEqual(
+            mock_channel.send.await_args.kwargs["embed"].description,
+            "test"
+        )
+        self.assertIsNone(mock_channel.send.await_args.kwargs["file"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cogs/admin/test_announcements.py
+++ b/src/cogs/admin/test_announcements.py
@@ -13,7 +13,12 @@ class TestAnnouncementFormatting(unittest.TestCase):
     def test_format_announcement_with_title_uses_single_newline(self):
         announcement = _format_announcement("my title", "test")
 
-        self.assertEqual(announcement, "**my title**\ntest")
+        self.assertEqual(announcement, "# my title\ntest")
+
+    def test_format_announcement_with_title_strips_leading_line_breaks_from_content(self):
+        announcement = _format_announcement("my title", "\n\ntest")
+
+        self.assertEqual(announcement, "# my title\ntest")
 
     def test_format_announcement_without_title_has_no_leading_newline(self):
         announcement = _format_announcement("", "test")
@@ -84,7 +89,29 @@ class TestAnnouncements(IsolatedAsyncioTestCase):
         await modal.on_submit(mock_interaction)
 
         mock_channel.send.assert_awaited_once_with(
-            content="**my title**\ntest",
+            content="# my title\ntest",
+            file=None
+        )
+
+    async def test_on_submit_regular_submission_drops_leading_line_breaks_in_content(self):
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+
+        mock_interaction = MagicMock(spec=Interaction)
+        mock_interaction.response = MagicMock()
+        mock_interaction.response.is_done = MagicMock(return_value=False)
+        mock_interaction.response.send_message = AsyncMock()
+        mock_interaction.followup = MagicMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        modal = Announcement(None, mock_channel, "regular")
+        modal.announcement_title = MagicMock(value="my title")
+        modal.announcement = MagicMock(value="\n\ntest")
+
+        await modal.on_submit(mock_interaction)
+
+        mock_channel.send.assert_awaited_once_with(
+            content="# my title\ntest",
             file=None
         )
 

--- a/src/ui/modals/announcement.py
+++ b/src/ui/modals/announcement.py
@@ -27,6 +27,14 @@ def _unique(iterable: list) -> list:
     return r
 
 
+def _format_announcement(title: str, content: str) -> str:
+    """Build the outgoing announcement body."""
+    if title and not title.isspace():
+        return f"**{title}**\n{content}"
+
+    return content
+
+
 class Announcement(Modal, title='Announcement'):
     announcement_title = TextInput(
         label='Title',
@@ -57,15 +65,14 @@ class Announcement(Modal, title='Announcement'):
 
     async def on_submit(self, interaction: Interaction) -> None:
         photo = None
-        announcement_title = ""
 
         if self.attachment:  # If the user has uploaded an attachment
             photo = await self.attachment.to_file()
 
-        if self.announcement_title.value:
-            announcement_title = f"**{self.announcement_title.value}**"
-
-        announcement = announcement_title + f'\n\n{self.announcement.value}'
+        announcement = _format_announcement(
+            self.announcement_title.value,
+            self.announcement.value
+        )
 
         if self.mention:
             selection_view = AnnouncementView()

--- a/src/ui/modals/announcement.py
+++ b/src/ui/modals/announcement.py
@@ -32,7 +32,8 @@ def _format_announcement(title: str, content: str) -> str:
     title = title.strip()
 
     if title:
-        return f"# {title}\n{content.lstrip('\r\n')}"
+        content = content.lstrip("\r\n")
+        return f"# {title}\n{content}"
 
     return content
 

--- a/src/ui/modals/announcement.py
+++ b/src/ui/modals/announcement.py
@@ -29,8 +29,10 @@ def _unique(iterable: list) -> list:
 
 def _format_announcement(title: str, content: str) -> str:
     """Build the outgoing announcement body."""
-    if title and not title.isspace():
-        return f"**{title}**\n{content}"
+    title = title.strip()
+
+    if title:
+        return f"# {title}\n{content.lstrip('\r\n')}"
 
     return content
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
This PR fixes the #279 issue where an extra whitespace is added between the title and content of an announcement

Fixes #279 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Mock test using unittest
- [x] Manual

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
